### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   "author": "Derik Evangelista <hi@derik.dev>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@backstage/backend-defaults": "^0.5.3",
-    "@backstage/backend-plugin-api": "^1.0.2",
-    "@backstage/config": "^1.3.0",
-    "@backstage/integration": "^1.15.2",
-    "@backstage/plugin-scaffolder-node": "^0.6.1",
-    "@kubernetes/client-node": "^0.20.0",
+    "@backstage/backend-defaults": "^0.8.1",
+    "@backstage/backend-plugin-api": "^1.2.0",
+    "@backstage/config": "^1.3.2",
+    "@backstage/integration": "^1.16.1",
+    "@backstage/plugin-scaffolder-node": "^0.7.0",
+    "@kubernetes/client-node": "^0.22.3",
     "js-yaml": "^4.1.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.2"
   },
   "files": [
     "dist"
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/kirederik/backstage-k8s-scaffolder-actions",
   "devDependencies": {
-    "@backstage/cli": "^0.29.2",
+    "@backstage/cli": "^0.30.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,33 +9,33 @@ importers:
   .:
     dependencies:
       '@backstage/backend-defaults':
-        specifier: ^0.5.3
-        version: 0.5.3(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))
+        specifier: ^0.8.1
+        version: 0.8.1(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))
       '@backstage/backend-plugin-api':
-        specifier: ^1.0.2
-        version: 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+        specifier: ^1.2.0
+        version: 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
       '@backstage/config':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.2
+        version: 1.3.2
       '@backstage/integration':
-        specifier: ^1.15.2
-        version: 1.15.2
+        specifier: ^1.16.1
+        version: 1.16.1
       '@backstage/plugin-scaffolder-node':
-        specifier: ^0.6.1
-        version: 0.6.1(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
+        specifier: ^0.7.0
+        version: 0.7.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
       '@kubernetes/client-node':
-        specifier: ^0.20.0
-        version: 0.20.0
+        specifier: ^0.22.3
+        version: 0.22.3
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
       zod:
-        specifier: ^3.24.1
-        version: 3.24.1
+        specifier: ^3.24.2
+        version: 3.24.2
     devDependencies:
       '@backstage/cli':
-        specifier: ^0.29.2
-        version: 0.29.2(@types/node@22.10.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))(type-fest@0.21.3)(typescript@5.7.2)
+        specifier: ^0.30.0
+        version: 0.30.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(@types/node@22.10.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))(type-fest@0.21.3)(typescript@5.7.2)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -251,8 +251,24 @@ packages:
     resolution: {integrity: sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==}
     engines: {node: '>=18.0.0'}
 
+  '@azure/core-http-compat@2.2.0':
+    resolution: {integrity: sha512-1kW8ZhN0CfbNOG6C688z5uh2yrzALE7dDXHiR9dY4vt+EbhGZQSbjDa5bQd2rf3X2pdWMsXbqbArxUyeNdvtmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
   '@azure/core-rest-pipeline@1.18.1':
     resolution: {integrity: sha512-/wS73UEDrxroUEVywEm7J0p2c+IIiVxyfigCGfsKvCxxCET4V/Hef2aURqltrXMRjNmdmt5IuOgIpl8f6xdO5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.19.0':
+    resolution: {integrity: sha512-bM3308LRyg5g7r3Twprtqww0R/r7+GyVxj4BafcmVPo4WQoGt5JXuaqxHEFjw2o3rvFZcUPiqJMg6WuvEEeVUA==}
     engines: {node: '>=18.0.0'}
 
   '@azure/core-tracing@1.2.0':
@@ -261,6 +277,10 @@ packages:
 
   '@azure/core-util@1.11.0':
     resolution: {integrity: sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-xml@1.4.4':
+    resolution: {integrity: sha512-J4FYAqakGXcbfeZjwjMzjNcpcH4E+JtEBv+xcV1yL0Ydn/6wbQfeFKTCHh9wttAi0lmajHw7yBbHPRG+YHckZQ==}
     engines: {node: '>=18.0.0'}
 
   '@azure/identity@4.5.0':
@@ -282,6 +302,10 @@ packages:
   '@azure/msal-node@2.16.2':
     resolution: {integrity: sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==}
     engines: {node: '>=16'}
+
+  '@azure/storage-blob@12.26.0':
+    resolution: {integrity: sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.0.0':
     resolution: {integrity: sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==}
@@ -908,8 +932,8 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@backstage/backend-app-api@1.0.2':
-    resolution: {integrity: sha512-o3FbzKBc8Y7yWaETuN6jPRumSh+LJE+MkuqcG3aUyjI99xsgRCQwK9eNGpt3wxLSxXJgoWI4AN52SYxH8xfYvw==}
+  '@backstage/backend-app-api@1.2.0':
+    resolution: {integrity: sha512-+wswk2ZJJHR5f2DUtOkl8pwtmLpTJhNkGJMsUOfbn5kKLCGPbgqUwcJa1lm7EKIb4mpoZY5rJtJ2ktlO8W8v3w==}
 
   '@backstage/backend-common@0.25.0':
     resolution: {integrity: sha512-TMQjoZLP80ek/NYBAcFvr8p5fioxuq6rC2Qd9FHXTifTzH9k31yJqmaTUmlJcw4+tz+3h4ss3qCwGGlgfNbGfQ==}
@@ -920,65 +944,61 @@ packages:
       pg-connection-string:
         optional: true
 
-  '@backstage/backend-defaults@0.5.3':
-    resolution: {integrity: sha512-pzXiwywWRi8CJfUQzbVwmVcxb7mDLtKOdNE1vjfoJUK29jDLyA4+FjBy/VkndTLiCHwPbtEVQ7eKCvt48EXQeQ==}
+  '@backstage/backend-defaults@0.8.1':
+    resolution: {integrity: sha512-EZj64SSTtaAjMac1n7zWLsjp1vuKw8hOIGrZxD7MdDVyGzn/hCn2KdW9enYYQfb7UJsx1PsgUUZIBQdSa3oJ2Q==}
+    peerDependencies:
+      '@google-cloud/cloud-sql-connector': ^1.4.0
+    peerDependenciesMeta:
+      '@google-cloud/cloud-sql-connector':
+        optional: true
 
   '@backstage/backend-dev-utils@0.1.5':
     resolution: {integrity: sha512-OMCoDN2m2otZfK1nOdW4+BbPVuAY7g+IYyzfkXmVGTb8M3yi5vGxsUpfJv24K25vaz54m65xBB29bOPSjxfzag==}
 
-  '@backstage/backend-plugin-api@1.0.2':
-    resolution: {integrity: sha512-XcTOx4ARR3JmV1y28jsi0SevQXxDF5KvOTn5D50G9XRIUnnlDMHiJjBg22kxDOZrckTlC7WWGuVe5LHnSTkcrA==}
+  '@backstage/backend-plugin-api@1.2.0':
+    resolution: {integrity: sha512-dugL00Qq+Cu4AqcUfraPZhC8jo+Pg4YPx9sKm4XIf+27ZbPBGLJMKrOmCOYpZXBKMMBY44h9/oeg5fO3RnHetg==}
 
   '@backstage/catalog-client@1.8.0':
     resolution: {integrity: sha512-+0DPzVwkJCTxY28VvUH7yg2087/JSyGZ7iHHShI40HAbsCitd5woJnmYa+2O1B8PuJxFbAYoZesh4uARp58NKg==}
 
-  '@backstage/catalog-model@1.7.1':
-    resolution: {integrity: sha512-TdtcpMzMMcSXlmJylEG2KbEHwxhd9XkxnvUFPKaF35Q6PjV9MhERw4qBSrINCzaIU5zn8baiyQBbg6j93r+kyA==}
+  '@backstage/catalog-client@1.9.1':
+    resolution: {integrity: sha512-8LpTbW3QQoNDNvPtHAlr1BUEbOZsbj2iGHbaZWBM6Hc+jHfl+VQC6pkHnG3XoeU6prXY/j6o4p/fDuxYEX22sQ==}
+
+  '@backstage/catalog-model@1.7.3':
+    resolution: {integrity: sha512-eqSRo7briHyVXMBkNdgQ8rdrw5W2LZifqrIabGwjcvoV8YDG2hFBuCPfqpdpfsgeCIk45iyXilTi9rg1Nt1fgw==}
 
   '@backstage/cli-common@0.1.15':
     resolution: {integrity: sha512-z+jMq5h+J1ruZ0IC610QFfSQxLk3IGSL1pZ/xnEIbyohaak+eeOZCyNzKBLwQrBDnIFCdmMoq69/Vrejo2hPeA==}
 
-  '@backstage/cli-node@0.2.10':
-    resolution: {integrity: sha512-dVsAR1dHr86PVC24+t1mTfzs6mWFjDAKHPPucDFGl9UK4ziO9n2x0HrLsp1t12AnHI4kTEdH66UgX54y+6F3Ag==}
+  '@backstage/cli-node@0.2.13':
+    resolution: {integrity: sha512-OozsAHEdIio9fY5pCpnSFPT5uH5ojAow6Ns0PDyhAgIEa3NGOUyoZ4g5QWHko7rh+kf3dmsltNDxSw/AREA1/A==}
 
-  '@backstage/cli@0.29.2':
-    resolution: {integrity: sha512-+fSOvJPI0oS8bCAeidsBZ0Kf4m0nFH8cFbk20Xr37KBQFqo1uxorht1j49HbGVIvM+vt+/mrMh1Xq9okRSfquA==}
+  '@backstage/cli@0.30.0':
+    resolution: {integrity: sha512-7uC9OzmyTUwpynoyJ6hXH/72Ymf+Kkq0ZaJQYQWqEpIgUEfJ5yiSjIvVSLj1raNlQFQ4Ea40XzZKKJG/pu2nRQ==}
     hasBin: true
     peerDependencies:
-      '@modyfi/vite-plugin-yaml': ^1.1.0
       '@rspack/core': ^1.0.10
       '@rspack/dev-server': ^1.0.9
       '@rspack/plugin-react-refresh': ^1.0.0
-      '@vitejs/plugin-react': ^4.0.4
-      vite: ^5.0.0
-      vite-plugin-html: ^3.2.0
-      vite-plugin-node-polyfills: ^0.22.0
     peerDependenciesMeta:
-      '@modyfi/vite-plugin-yaml':
-        optional: true
       '@rspack/core':
         optional: true
       '@rspack/dev-server':
         optional: true
       '@rspack/plugin-react-refresh':
         optional: true
-      '@vitejs/plugin-react':
-        optional: true
-      vite:
-        optional: true
-      vite-plugin-html:
-        optional: true
-      vite-plugin-node-polyfills:
-        optional: true
 
   '@backstage/config-loader@1.9.2':
     resolution: {integrity: sha512-RjE3FjgiKzn8ZTvFI+KjSkEPQR5/6ak1RO9bDO2EEG+UJKc6TXPTikMojeTx0ZwsIfGaXQKfKZBxhCOxelSJJQ==}
 
-  '@backstage/config@1.3.0':
-    resolution: {integrity: sha512-DXrcPIwgZAHrKj3MRHt6yC63E1/LXXgM0hdAFJYkRYb7r+VX3KGBfxo1NtWdB6A4gTXhxfEWc7FWvdloIDDoGg==}
+  '@backstage/config-loader@1.9.6':
+    resolution: {integrity: sha512-PfldxhIEobC+JALA3UiyW8ezp+eeEoTlnAqvx8tF5SaGzGDaF/mqBZQXQjqd/YrozK95xR/vKlFFf/WQEfjcwA==}
 
-  '@backstage/errors@1.2.5':
-    resolution: {integrity: sha512-JoLzSdCt5uHPYvC/aR/UE10+d1WlTEsR0L7xWBgcTluC9VUpFmV5W15bNL+ckZHi14nQV3V1DOk9uhsR1ER45w==}
+  '@backstage/config@1.3.2':
+    resolution: {integrity: sha512-9na5EAf5AJzrwAysnIbNqFmPN1ES9IiUwy9uGMhwFzxXeHjDz+RAmiqFYFL6tNMwuFwrW1zxpvzKAUXvvYDe6Q==}
+
+  '@backstage/errors@1.2.7':
+    resolution: {integrity: sha512-XsH0w4hW0aJs3NuANbvgpQoKrQGYIMUaVKeDoGO/99uDgBbJ2QyDb/m9onbKV7tG9HkEe/NKixKqRhxRLx4wzA==}
 
   '@backstage/eslint-plugin@0.1.10':
     resolution: {integrity: sha512-5TFU4/loQpPKPiuOyqhaFNvl1GpkHzIU40Z7WdMmnrrbMkoYxtg2yRttwb17ckF8lRp3wqvi72yvW1lqHA+ahw==}
@@ -986,32 +1006,38 @@ packages:
   '@backstage/integration-aws-node@0.1.13':
     resolution: {integrity: sha512-VVReNP+BPDdnkzq9V7+KDfby+jPOIZM8S22pGiwVYCGt6cVpgOkz0M9b1ZwNQDyqnAxvlv3Yal1PaCx/XKsbWw==}
 
-  '@backstage/integration@1.15.2':
-    resolution: {integrity: sha512-cCigk62u4Ikkr3J/APf0ZFpT5F7HCM/iT+hJh4n9a/ufipu945X5QfgO7odsTL5uG8YgzbU1xl25W/Z/PGuWIw==}
+  '@backstage/integration-aws-node@0.1.15':
+    resolution: {integrity: sha512-936tY7ywpDU7/+soAxSk28kNPsJuafETvTFQv3GAljBExFMMCkXiuplIUKNSPCbvNVo5V5J6Z/nyHVMNY/Wz7Q==}
+
+  '@backstage/integration@1.16.1':
+    resolution: {integrity: sha512-HDJo+TTiup/vj308plzQSo12kFk3BIY6fSPm9V1FgijDRq5145+iMcJAhQf/dGMIykXTQ+Dsc+FMJfCPO5VRMA==}
 
   '@backstage/plugin-auth-node@0.5.4':
     resolution: {integrity: sha512-XoKVmF1S9GrqdfSRsFUY9tnXB2bcuQJAVVrZzx7OUpY+O1ED/dFwAwxPtIrC1EkhoYvzM6IUCik8CR6k5fAJLA==}
 
-  '@backstage/plugin-events-node@0.4.5':
-    resolution: {integrity: sha512-Uw+JY4kPdta1HM+HkOOWzaPMiBDOji0oaCfVPVZe6drfEJnRAGn11lVIZDoinN8ua8lp26wpmVz1J4yr5oFjDA==}
+  '@backstage/plugin-auth-node@0.6.0':
+    resolution: {integrity: sha512-SiQ5H/ZCRkIi5dXDhfd71VvFl9UGW8MEpwe0G8B+5gCiiNGLKq31vHQS9jYZ2eI1aRqvsksOeVDgcN5aAE25Og==}
 
-  '@backstage/plugin-permission-common@0.8.2':
-    resolution: {integrity: sha512-rq8AMUufiFMOUeXZAJ/y1JzRpUSRFVs7ddhtsmX5nvkZP07ONT8WwnVZPYFywfX8rDt/Ym4wZuPnPk4xqHX04A==}
+  '@backstage/plugin-events-node@0.4.8':
+    resolution: {integrity: sha512-eSdQbyEYUqg0SQBewCyTERpB6ncWVQ6uKV5dLY56m5W1HzeE+XeBRmOHCN4Pf9VuwAL8OYfFqi8JnCIkaygc8Q==}
 
-  '@backstage/plugin-permission-node@0.8.5':
-    resolution: {integrity: sha512-fj9y5Vb2GR8/u4ejhLUrozRnk8oQBb8I4XyOW2DAYkAyKA40OJMlVHvudY+13likb6TS0ByXSuhQWYSpQbUD3g==}
+  '@backstage/plugin-permission-common@0.8.4':
+    resolution: {integrity: sha512-zZSfXadycRCP/YG2Cf4p/hxDU4fhrYDAVneo9PKZMfy3O4ERdtrYehGuOspcak2NkeMmaj2KfsFuWFuWK2xBTQ==}
 
-  '@backstage/plugin-scaffolder-common@1.5.7':
-    resolution: {integrity: sha512-hHtgXiFi6Fbta7rXHV/0jGB4Cguig33Qjah07ZPXp5wfz4aVvn3YYV/z8aezExxLtoqVYUpwn8PkasFh0opoPg==}
+  '@backstage/plugin-permission-node@0.8.8':
+    resolution: {integrity: sha512-CCOjbKFyaZB81fxc/+HAzTsHWfY07XUb6KGNw4D0UlObMLfozfJX09/wvOEM51jDWo+E1YprZ/HJ9CafGfWvgg==}
 
-  '@backstage/plugin-scaffolder-node@0.6.1':
-    resolution: {integrity: sha512-GjL/C1fESkCD/x5zwGhQ4JKZRakZTZ8lcbYvmd97IXcX7ZQHNcpDqew5fEBmCeTb+FDo0i9NNs8c5GOlzwZXQg==}
+  '@backstage/plugin-scaffolder-common@1.5.9':
+    resolution: {integrity: sha512-lcUQDzn/YjnsBnMGVA+Z7XbDS7T4nc8wdMO+D15WDfkC/WVVmWdRnlkfM0UTuWPg7QMIkUtqpFplidkNNwWf5w==}
 
-  '@backstage/release-manifests@0.0.11':
-    resolution: {integrity: sha512-OZFwv7ohRRB9fDQ+fShgQgM5H4VvKXAtvErSjZCmqGnUiNpyT9e/km0wF2/QVTm2ry5kCEj37f/B/dDp0gmNAw==}
+  '@backstage/plugin-scaffolder-node@0.7.0':
+    resolution: {integrity: sha512-2DfssnzUreJEatTbL/Iipp2u+ZzVVY9RaavPjzPdE4kIn94hc4j9vAkgpVGAhLIFXH9/fCYQBxV/MZDu7xk+eg==}
 
-  '@backstage/types@1.2.0':
-    resolution: {integrity: sha512-YoWvCLJNOgvRXSqH8EoWmmQ8G8+emiYpn5dqDZcMrqAA6Xa8yFFVsQTujEusx5ZSwahPMbSDobNJgiSoXL3XyA==}
+  '@backstage/release-manifests@0.0.12':
+    resolution: {integrity: sha512-qJDQXVvggK9OjaiGyAK6Scpga0Mq6tKKOgtrwqWHzdkNjvM9Klp0UZtluF8B7e3fc9l8mBX8BVIcrzinlKg2lQ==}
+
+  '@backstage/types@1.2.1':
+    resolution: {integrity: sha512-0GkrZthoIkUzoeop+8fZZk2MWlLd1q0LB59tMarsjw7ccMtFYR96jhlf1qGvcbw7Gn5ETtJfTC2C1aUzvgvF+w==}
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -1369,6 +1395,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -1471,6 +1501,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
     engines: {node: '>=10.0'}
@@ -1492,12 +1534,25 @@ packages:
   '@keyv/memcache@1.4.1':
     resolution: {integrity: sha512-BoXgJG3xZO6J3JPuJGzbP+gyc1QcqzEK7o0SP7TFdMu+AXJ8LAXflCqJug3BmDNTCnBb3mqUgMr01EOhJ+CqWw==}
 
+  '@keyv/memcache@2.0.1':
+    resolution: {integrity: sha512-JavNaKi/9L/+amZ0k7EH5odYb6napHJu388jv4Q04gtT8CR4ObRBIuhVBgOyTYa+KxLCs5RqckZgP5Sj/GjSUA==}
+
   '@keyv/redis@2.8.5':
     resolution: {integrity: sha512-e9W1faN32A1Wy5726qtorAvPu1Xffh75ngfQQtETQ0hIN/FQtK0RcBTz/OH/vwDvLX8zrzdu0sWq/KoSHDYfVw==}
     engines: {node: '>= 14'}
 
+  '@keyv/redis@4.2.0':
+    resolution: {integrity: sha512-QszmBfZZ3wOKJ5z1hn0CTLf04WN/552ITrSDYC3Yg4jT6yVdlz2fJxi5CNrnZ8NIu/Qaj7OAkbSL+pyFUXp6oA==}
+    engines: {node: '>= 18'}
+
+  '@keyv/serialize@1.0.3':
+    resolution: {integrity: sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==}
+
   '@kubernetes/client-node@0.20.0':
     resolution: {integrity: sha512-xxlv5GLX4FVR/dDKEsmi4SPeuB49aRc35stndyxcC73XnUEEwF39vXbROpHOirmDse8WE9vxOjABnSVS+jb7EA==}
+
+  '@kubernetes/client-node@0.22.3':
+    resolution: {integrity: sha512-dG8uah3+HDJLpJEESshLRZlAZ4PgDeV9mZXT0u1g7oy4KMRzdZ7n5g0JEIlL6QhK51/2ztcIqURAnjfjJt6Z+g==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -1508,17 +1563,17 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@module-federation/bridge-react-webpack-plugin@0.7.7':
-    resolution: {integrity: sha512-5E+pAF8Niw+svROrD0x2F/QlhGb2/fRupN6xN2yvcKofMSdvY9/2txKKWSw0E51HFlKslb9MWLenayOfJtT+VA==}
+  '@module-federation/bridge-react-webpack-plugin@0.8.12':
+    resolution: {integrity: sha512-fiSf9Df4RqdKiL1WtS7eCqAWqDnLNwMZ9qU7ZMjXSAhI3wOLzycFflpVx7PWOxSoTJPtc61hwD5lkEpNoHezkg==}
 
-  '@module-federation/data-prefetch@0.7.7':
-    resolution: {integrity: sha512-SDiXE4LtXujR3A0bM9gN+ChpyZmAVkmic8bTSbs+o6a+WKtIkxcBrwPaFTkijlvSkcda310R6YGBqSbajKQ90w==}
+  '@module-federation/data-prefetch@0.8.12':
+    resolution: {integrity: sha512-YjCk6KPBQ4Ml2/2aIKQt11I4jBKOTvK3xHyAQMKPpX5aBbMEwonDhkpTitygUw3SMBdi3CP1KMRDJ3suj3O6Mg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@module-federation/dts-plugin@0.7.7':
-    resolution: {integrity: sha512-ct4O/J3f/wVcvEXKDCe83r3LIfQTMy+aTej2RJwZZT+6mlA82cQ9FZgsCY60FAKtsr3UcOPSGEPxAwXQ5iKChA==}
+  '@module-federation/dts-plugin@0.8.12':
+    resolution: {integrity: sha512-BhRZsG68XtGzKM0N02/3ldiW+PTc+QaHCMNyiZnk3GcxS0qe6USu7fTQwRIPCC2GONIdoHD+GVYPN/NJWjbTFg==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -1526,8 +1581,8 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/enhanced@0.7.7':
-    resolution: {integrity: sha512-uuaQCbzyfVcqOz1+Kq5TScExvM+AuzFXBgWxTvop68RufVzf0eRsvTTLBgnrq7b/2loRxzOzrbCciNeTsXCYXA==}
+  '@module-federation/enhanced@0.8.12':
+    resolution: {integrity: sha512-uJODfWqL3C87LUu1E0ZLPRqE0sUt6QFH97bMFoCWYhkf8JS7J+wMc4KSc31ApaJs7CeQICXR1CYBAZDSdxkrOQ==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -1540,18 +1595,27 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/error-codes@0.7.7':
-    resolution: {integrity: sha512-c38UWAIeK7n7MihCD4fnvD7/Bdh6G2jCwyF+bzold8BYFmId/ck2+tvRoX7qX6qeftWJr61PBfJceffozujG0w==}
+  '@module-federation/error-codes@0.8.12':
+    resolution: {integrity: sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==}
 
-  '@module-federation/managers@0.7.7':
-    resolution: {integrity: sha512-tdqhcsEg7R2XwdzC4XTwMfrHLzThYiThmSThOTKZ3NKUPKmQlPJqzYD9ejFwH56X43iy2U8X8IsNkiNG2rqAwQ==}
+  '@module-federation/error-codes@0.8.4':
+    resolution: {integrity: sha512-55LYmrDdKb4jt+qr8qE8U3al62ZANp3FhfVaNPOaAmdTh0jHdD8M3yf5HKFlr5xVkVO4eV/F/J2NCfpbh+pEXQ==}
 
-  '@module-federation/manifest@0.7.7':
-    resolution: {integrity: sha512-+NBk0y6t27GT2rfltGQ9CZMzyZ8+mJU8QfQ/Ih/N6l8avbt49IXL5ZuRNiFge4YK2J3hF2ptu74ZICe46d4fgQ==}
-
-  '@module-federation/rspack@0.7.7':
-    resolution: {integrity: sha512-VDp8sWwlf2ByhMM1Ab8yG+6chBsYGghZJpqQvbikpsEHXdnk1W+YnRBdMulimeAQLupyZn2QsS8VuWqj860UlQ==}
+  '@module-federation/inject-external-runtime-core-plugin@0.8.12':
+    resolution: {integrity: sha512-/vFW+eiBiqXOKkDYVKl5JXGI0H4Whj10P8JadowxuHcEuR+R7kkXXauYuGYKaxIFqG4zbN3r9su2qxIEEqOsOw==}
     peerDependencies:
+      '@module-federation/runtime-tools': 0.8.12
+
+  '@module-federation/managers@0.8.12':
+    resolution: {integrity: sha512-+BBdBMptHiiT2ZsfPovQuHYkse6R1+dmDS6bAinw3UGpb418W8ERp5I4jHeyhEtr3t3mb/dh4sAsYM14/EWJ9Q==}
+
+  '@module-federation/manifest@0.8.12':
+    resolution: {integrity: sha512-UwC6/QK37x7Xr5K+89iKxOy/uQHqFMd49axOhgDmFSrWQOULFQd51EpTOxFXgwZfiq/h0uVBYq/c0GB3Tdu8GA==}
+
+  '@module-federation/rspack@0.8.12':
+    resolution: {integrity: sha512-G73Cq7VwKdpFZwMd9hEBsE2HLF7mNQEIvLSiW6HOZG/+iWRRED1opiVkrjOmkcg770rChYSqTBiLvUS7HDT5Ow==}
+    peerDependencies:
+      '@rspack/core': '>=0.7'
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
     peerDependenciesMeta:
@@ -1560,20 +1624,35 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/runtime-tools@0.7.7':
-    resolution: {integrity: sha512-K0JFXBqU8BflZc9fS0tJx/HW1lhw4lj1zG0ILsdTtyMPFGfl4sv3rXvMC4mI9AFx2ZmvH0HiuE0rBCR7iSQE/Q==}
+  '@module-federation/runtime-core@0.6.20':
+    resolution: {integrity: sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==}
 
-  '@module-federation/runtime@0.7.7':
-    resolution: {integrity: sha512-Px9VL5dcX/dZ+QcNl1vdJNeVf+BYHb11W0uHV645A30Zw/lyzUwdK5aso0oEd8H8fCvennwJipOW5rkS738QJg==}
+  '@module-federation/runtime-tools@0.8.12':
+    resolution: {integrity: sha512-H97wR/toSU9+UO9S0VHLmPg/7QgohMI52EZlR0Kh0F4PD6fbiWuO4kBIp7R6g0dMI9D4NVKWTKV8xA9ASU+k7g==}
 
-  '@module-federation/sdk@0.7.7':
-    resolution: {integrity: sha512-UMiw+WvgNwc4gw3X0aST7uP9qnfPaOoynY922Vl+JB30NT8MM8jAp/tAoyYARFbB5MNyZF0UicE8dDT2yYHgcw==}
+  '@module-federation/runtime-tools@0.8.4':
+    resolution: {integrity: sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==}
 
-  '@module-federation/third-party-dts-extractor@0.7.7':
-    resolution: {integrity: sha512-5hCJVOy0I1UVexHBaYxObaT88vLG/pgua0i3IZL9thKUqugJAGR8HfvgGpd1LKUBbue41MAhysHSQjHp7HQukQ==}
+  '@module-federation/runtime@0.8.12':
+    resolution: {integrity: sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==}
 
-  '@module-federation/webpack-bundler-runtime@0.7.7':
-    resolution: {integrity: sha512-zqc41cCRUqwGwjAHoNPZUefEVnx/3xwzHrOSqlff7mwTmXcFh5Ua/AqJcwAPYF4bYOVvj87aQn8k71CgpbVb/g==}
+  '@module-federation/runtime@0.8.4':
+    resolution: {integrity: sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==}
+
+  '@module-federation/sdk@0.8.12':
+    resolution: {integrity: sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==}
+
+  '@module-federation/sdk@0.8.4':
+    resolution: {integrity: sha512-waABomIjg/5m1rPDBWYG4KUhS5r7OUUY7S+avpaVIY/tkPWB3ibRDKy2dNLLAMaLKq0u+B1qIdEp4NIWkqhqpg==}
+
+  '@module-federation/third-party-dts-extractor@0.8.12':
+    resolution: {integrity: sha512-+ZO5XpBwEhP9v/Tqk51YgswwbAzj4TXKZ54++uVDsLnOh9yydVGJ/b5pQcSrc8B1C55+498tsDEcNsFgZODgMQ==}
+
+  '@module-federation/webpack-bundler-runtime@0.8.12':
+    resolution: {integrity: sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==}
+
+  '@module-federation/webpack-bundler-runtime@0.8.4':
+    resolution: {integrity: sha512-HggROJhvHPUX7uqBD/XlajGygMNM1DG0+4OAkk8MBQe4a18QzrRNzZt6XQbRTSG4OaEoyRWhQHvYD3Yps405tQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1712,6 +1791,35 @@ packages:
         optional: true
       webpack-plugin-serve:
         optional: true
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.0':
+    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@rollup/plugin-commonjs@26.0.3':
     resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
@@ -1856,6 +1964,70 @@ packages:
     resolution: {integrity: sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==}
     cpu: [x64]
     os: [win32]
+
+  '@rspack/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-31URF3tAgVR8Pt6Oc8MANV/gYNR6DlUhtIMmWM2EwdcWTyIEnN7gSDdjtB6cYvETHwdM7NDSCOgyIirG1+tNZw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-0XJMOGEqERP9N8zgJxfdWzuZG9buEp6RL4PSVaXPvcKw75Ig3YW50A8sMqd4SNXAqJp2gC706d6l8OnMXpRo3w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-Ld26wvy9NSTqhUb/ll5ZpIW08ZzUkTl5daW3xHJgcaoRDrnJkRV1pMx8cdV8S+xsavJIPf4c+BuKpU6Ml2kx9A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-TrklgPKngiuzRovr7MdXDKXPfjJlT3g5LmCX/Y4pPfNrrOLjzL/fpEBRXBJEhrSuNWqpkZSNLs+Av02IY7manQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-aZ6mrZyuUg8hlBf7qEfXRAVPh2tM8E7kYZhI5eBOUoi6XhO5fTVcf/S2VUimFWLUmJdmSujG+nrYGQu1n74Xag==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-Trg+s1b6sD4XNMOvwWwI+cebwGOBEXsND9Ofjc6L1RPtCeZQ5Rrycfh/HVymI50Y48g8YMibLZw8G2gAfK8SZw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-lEWMW8H5ERYX376NA2qGritCHmcMNW+Ob6WVWuEZNh0oWeBD/mWqWFxbCx5J3KtlVy4miwk65V8YDd92alUEyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.2.6':
+    resolution: {integrity: sha512-ML3f7vDyv2c7d+ync6l3aRY4cIAKUPT5n+yz7sRcwIBrB4n1n4rH6wf5a56h4wHjiWpnV0gXBXI9SrYD5a4vRQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-0W0iComo7cdOg5fOuaZ2l1Mz7DG1A4SPDes557n9CH2Tf5rub3m2rBoMQ1B/XIkcUeGf+oB6bbBBroHPH0vQBA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@1.2.6':
+    resolution: {integrity: sha512-Szu9w+RktSunBNfIHDORY/YRLFplhnUF9QgpUles8XYzKo6NA96WQNJoFbrBDkEQPbNUtVpEk4Ua1c9ZWtVTJQ==}
+
+  '@rspack/core@1.2.6':
+    resolution: {integrity: sha512-CYiz6kXWdZX0tKu819Bromg84W9+GrgSY7OTMtr39IKRcCHjdVVjPYFthga2bNppfT+Ifeti5Ed06Xxlptr9CQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@rspack/tracing': ^1.x
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@rspack/tracing':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/lite-tapable@1.0.1':
+    resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
+    engines: {node: '>=16.0.0'}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -2483,56 +2655,55 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@typescript-eslint/eslint-plugin@6.21.0':
-    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/eslint-plugin@8.25.0':
+    resolution: {integrity: sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/parser@6.21.0':
-    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/parser@8.25.0':
+    resolution: {integrity: sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/scope-manager@6.21.0':
-    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/scope-manager@7.18.0':
+    resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/scope-manager@8.18.0':
     resolution: {integrity: sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@6.21.0':
-    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/scope-manager@8.25.0':
+    resolution: {integrity: sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@6.21.0':
-    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/type-utils@8.25.0':
+    resolution: {integrity: sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/types@7.18.0':
+    resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/types@8.18.0':
     resolution: {integrity: sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@6.21.0':
-    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/types@8.25.0':
+    resolution: {integrity: sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@7.18.0':
+    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2545,11 +2716,17 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@6.21.0':
-    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/typescript-estree@8.25.0':
+    resolution: {integrity: sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/utils@7.18.0':
+    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
 
   '@typescript-eslint/utils@8.18.0':
     resolution: {integrity: sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==}
@@ -2558,12 +2735,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/visitor-keys@6.21.0':
-    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/utils@8.25.0':
+    resolution: {integrity: sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/visitor-keys@7.18.0':
+    resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/visitor-keys@8.18.0':
     resolution: {integrity: sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.25.0':
+    resolution: {integrity: sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.1':
@@ -2823,8 +3011,8 @@ packages:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
 
-  assert@1.5.1:
-    resolution: {integrity: sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==}
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -3000,6 +3188,9 @@ packages:
   brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
+  browser-resolve@2.0.0:
+    resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
+
   browserify-aes@1.2.0:
     resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
 
@@ -3051,9 +3242,6 @@ packages:
 
   buffer-xor@1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
-
-  buffer@4.9.2:
-    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -3113,6 +3301,9 @@ packages:
   caniuse-lite@1.0.30001687:
     resolution: {integrity: sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==}
 
+  caniuse-lite@1.0.30001701:
+    resolution: {integrity: sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==}
+
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
@@ -3148,6 +3339,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -3420,12 +3615,12 @@ packages:
     peerDependencies:
       postcss: ^8.0.9
 
-  css-loader@7.1.2:
-    resolution: {integrity: sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==}
-    engines: {node: '>= 18.12.0'}
+  css-loader@6.11.0:
+    resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
+    engines: {node: '>= 12.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
-      webpack: ^5.27.0
+      webpack: ^5.0.0
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -3689,9 +3884,9 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
-  domain-browser@1.2.0:
-    resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
-    engines: {node: '>=0.4', npm: '>=1.2'}
+  domain-browser@4.22.0:
+    resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
+    engines: {node: '>=10'}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -3899,10 +4094,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-deprecation@2.0.0:
-    resolution: {integrity: sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==}
+  eslint-plugin-deprecation@3.0.0:
+    resolution: {integrity: sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
 
   eslint-plugin-import@2.31.0:
@@ -3934,11 +4129,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-react-hooks@4.6.2:
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
+  eslint-plugin-react-hooks@5.1.0:
+    resolution: {integrity: sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.2:
     resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
@@ -3946,19 +4141,14 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-unused-imports@3.2.0:
-    resolution: {integrity: sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  eslint-plugin-unused-imports@4.1.4:
+    resolution: {integrity: sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': 6 - 7
-      eslint: '8'
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
-
-  eslint-rule-composer@0.3.0:
-    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
-    engines: {node: '>=4.0.0'}
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -4317,6 +4507,10 @@ packages:
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4819,6 +5013,10 @@ packages:
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -4941,6 +5139,14 @@ packages:
   isomorphic-rslog@0.0.6:
     resolution: {integrity: sha512-HM0q6XqQ93psDlqvuViNs/Ea3hAyGDkIdVAHlrEocjjAwGrs1fZ+EdQjS9eUPacnYB7Y8SoDdSY3H8p3ce205A==}
     engines: {node: '>=14.17.6'}
+
+  isomorphic-rslog@0.0.7:
+    resolution: {integrity: sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==}
+    engines: {node: '>=14.17.6'}
+
+  isomorphic-timers-promises@1.0.1:
+    resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
+    engines: {node: '>=10'}
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -5132,6 +5338,9 @@ packages:
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
+  jose@6.0.8:
+    resolution: {integrity: sha512-EyUPtOKyTYq+iMOszO42eobQllaIjJnwkZ2U93aJzNyPibCy7CEvT9UQnaCVB51IAd49gbNdCew1c0LcLTCB2g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5154,6 +5363,10 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -5214,6 +5427,11 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsonpath-plus@10.3.0:
+    resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   jsonpath-plus@7.2.0:
     resolution: {integrity: sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==}
     engines: {node: '>=12.0.0'}
@@ -5254,6 +5472,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  keyv@5.2.3:
+    resolution: {integrity: sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -5578,10 +5799,6 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5608,11 +5825,20 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.0.1:
+    resolution: {integrity: sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5698,15 +5924,16 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-libs-browser@2.2.1:
-    resolution: {integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==}
-
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   node-schedule@2.1.1:
     resolution: {integrity: sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==}
     engines: {node: '>=6'}
+
+  node-stdlib-browser@1.3.1:
+    resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
+    engines: {node: '>=10'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5742,6 +5969,9 @@ packages:
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
+  oauth4webapi@3.3.0:
+    resolution: {integrity: sha512-ZlozhPlFfobzh3hB72gnBFLjXpugl/dljz1fJSRdqaV2r3D5dmi5lg2QWI0LmUYuazmE+b5exsloEv6toUtw9g==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5752,6 +5982,10 @@ packages:
 
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -5821,6 +6055,9 @@ packages:
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
+  openid-client@6.3.3:
+    resolution: {integrity: sha512-lTK8AV8SjqCM4qznLX0asVESAwzV39XTVdfMAM185ekuaZCnkWdPzcxMTXNlsm9tsUAMa1Q30MBmKAykdT1LWw==}
+
   optionator@0.8.3:
     resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
     engines: {node: '>= 0.8.0'}
@@ -5871,6 +6108,10 @@ packages:
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
+
+  p-throttle@4.1.1:
+    resolution: {integrity: sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==}
+    engines: {node: '>=10'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -5928,9 +6169,6 @@ packages:
   passport@0.7.0:
     resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
-
-  path-browserify@0.0.1:
-    resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -6055,6 +6293,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-dir@5.0.0:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
+    engines: {node: '>=10'}
 
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
@@ -6486,6 +6728,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  redis@4.7.0:
+    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
+
   reflect.getprototypeof@1.0.8:
     resolution: {integrity: sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==}
     engines: {node: '>= 0.4'}
@@ -6602,6 +6847,10 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   ripemd160@2.0.2:
@@ -6893,8 +7142,8 @@ packages:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
 
-  stream-browserify@2.0.2:
-    resolution: {integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==}
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
   stream-buffers@3.0.3:
     resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
@@ -6903,8 +7152,8 @@ packages:
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
 
-  stream-http@2.8.3:
-    resolution: {integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==}
+  stream-http@3.2.0:
+    resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
@@ -7075,6 +7324,10 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
@@ -7155,9 +7408,6 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
-  to-arraybuffer@1.0.1:
-    resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -7204,6 +7454,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.0.1:
+    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -7227,9 +7483,6 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -7237,14 +7490,8 @@ packages:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
 
-  tsutils@3.21.0:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-
-  tty-browserify@0.0.0:
-    resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
+  tty-browserify@0.0.1:
+    resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -7333,6 +7580,10 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici@7.3.0:
+    resolution: {integrity: sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==}
+    engines: {node: '>=20.18.1'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7396,12 +7647,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  util@0.10.4:
-    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
-
-  util@0.11.1:
-    resolution: {integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==}
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -7641,6 +7886,10 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
@@ -7704,8 +7953,8 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
 
@@ -8375,7 +8624,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/core-http-compat@2.2.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.9.2
+      '@azure/core-rest-pipeline': 1.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
+      tslib: 2.8.1
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@azure/core-rest-pipeline@1.18.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.9.0
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-rest-pipeline@1.19.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
@@ -8395,6 +8676,11 @@ snapshots:
   '@azure/core-util@1.11.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
+      tslib: 2.8.1
+
+  '@azure/core-xml@1.4.4':
+    dependencies:
+      fast-xml-parser: 4.5.0
       tslib: 2.8.1
 
   '@azure/identity@4.5.0':
@@ -8431,6 +8717,24 @@ snapshots:
       '@azure/msal-common': 14.16.0
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
+
+  '@azure/storage-blob@12.26.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.9.0
+      '@azure/core-client': 1.9.2
+      '@azure/core-http-compat': 2.2.0
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.18.1
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/core-xml': 1.4.4
+      '@azure/logger': 1.1.4
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/code-frame@7.0.0':
     dependencies:
@@ -9230,22 +9534,20 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@backstage/backend-app-api@1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/express@4.17.21)(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
+  '@backstage/backend-app-api@1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/backend-plugin-api': 1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
       '@backstage/cli-common': 0.1.15
-      '@backstage/config': 1.3.0
-      '@backstage/config-loader': 1.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))
-      '@backstage/errors': 1.2.5
-      '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/plugin-permission-node': 0.8.5(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/types': 1.2.0
+      '@backstage/config': 1.3.2
+      '@backstage/config-loader': 1.9.6(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
       '@manypkg/get-packages': 1.1.3
       compression: 1.7.5
       cookie: 0.7.2
       cors: 2.8.5
-      express: 4.21.2
-      express-promise-router: 4.1.1(@types/express@4.17.21)(express@4.21.2)
       helmet: 6.2.0
       jose: 5.9.6
       knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
@@ -9255,7 +9557,6 @@ snapshots:
       minimatch: 9.0.5
       minimist: 1.2.8
       morgan: 1.10.0
-      node-fetch: 2.7.0
       node-forge: 1.3.1
       path-to-regexp: 8.2.0
       selfsigned: 2.4.1
@@ -9268,7 +9569,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - '@swc/core'
       - '@swc/wasm'
-      - '@types/express'
       - aws-crt
       - better-sqlite3
       - bufferutil
@@ -9291,15 +9591,15 @@ snapshots:
       '@aws-sdk/credential-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
       '@aws-sdk/types': 3.709.0
       '@backstage/backend-dev-utils': 0.1.5
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/backend-plugin-api': 1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
       '@backstage/cli-common': 0.1.15
-      '@backstage/config': 1.3.0
+      '@backstage/config': 1.3.2
       '@backstage/config-loader': 1.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))
-      '@backstage/errors': 1.2.5
-      '@backstage/integration': 1.15.2
+      '@backstage/errors': 1.2.7
+      '@backstage/integration': 1.16.1
       '@backstage/integration-aws-node': 0.1.13(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
       '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/types': 1.2.0
+      '@backstage/types': 1.2.1
       '@google-cloud/storage': 7.14.0
       '@keyv/memcache': 1.4.1
       '@keyv/redis': 2.8.5
@@ -9366,30 +9666,115 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@backstage/backend-defaults@0.5.3(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))':
+  '@backstage/backend-common@0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)':
     dependencies:
       '@aws-sdk/abort-controller': 3.374.0
       '@aws-sdk/client-codecommit': 3.709.0
       '@aws-sdk/client-s3': 3.709.0
       '@aws-sdk/credential-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
       '@aws-sdk/types': 3.709.0
-      '@backstage/backend-app-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/express@4.17.21)(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
       '@backstage/backend-dev-utils': 0.1.5
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/backend-plugin-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
       '@backstage/cli-common': 0.1.15
-      '@backstage/cli-node': 0.2.10
-      '@backstage/config': 1.3.0
+      '@backstage/config': 1.3.2
       '@backstage/config-loader': 1.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))
-      '@backstage/errors': 1.2.5
-      '@backstage/integration': 1.15.2
+      '@backstage/errors': 1.2.7
+      '@backstage/integration': 1.16.1
       '@backstage/integration-aws-node': 0.1.13(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
-      '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/plugin-events-node': 0.4.5(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
-      '@backstage/plugin-permission-node': 0.8.5(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/types': 1.2.0
+      '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
       '@google-cloud/storage': 7.14.0
       '@keyv/memcache': 1.4.1
       '@keyv/redis': 2.8.5
+      '@kubernetes/client-node': 0.20.0
+      '@manypkg/get-packages': 1.1.3
+      '@octokit/rest': 19.0.13
+      '@types/cors': 2.8.17
+      '@types/dockerode': 3.3.32
+      '@types/express': 4.17.21
+      '@types/luxon': 3.4.2
+      '@types/webpack-env': 1.18.5
+      archiver: 7.0.1
+      base64-stream: 1.0.0
+      compression: 1.7.5
+      concat-stream: 2.0.0
+      cors: 2.8.5
+      dockerode: 4.0.2
+      express: 4.21.2
+      express-promise-router: 4.1.1(@types/express@4.17.21)(express@4.21.2)
+      fs-extra: 11.2.0
+      git-url-parse: 14.1.0
+      helmet: 6.2.0
+      isomorphic-git: 1.27.2
+      jose: 5.9.6
+      keyv: 4.5.4
+      knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      lodash: 4.17.21
+      logform: 2.7.0
+      luxon: 3.5.0
+      minimatch: 9.0.5
+      minimist: 1.2.8
+      morgan: 1.10.0
+      mysql2: 3.11.5
+      node-fetch: 2.7.0
+      node-forge: 1.3.1
+      p-limit: 3.1.0
+      path-to-regexp: 8.2.0
+      pg: 8.13.1
+      pg-format: 1.0.4
+      raw-body: 2.5.2
+      selfsigned: 2.4.1
+      stoppable: 1.1.0
+      tar: 6.2.1
+      triple-beam: 1.4.1
+      uuid: 9.0.1
+      winston: 3.17.0
+      winston-transport: 4.9.0
+      yauzl: 3.2.0
+      yn: 4.0.0
+    optionalDependencies:
+      pg-connection-string: 2.7.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/backend-defaults@0.8.1(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))':
+    dependencies:
+      '@aws-sdk/abort-controller': 3.374.0
+      '@aws-sdk/client-codecommit': 3.709.0
+      '@aws-sdk/client-s3': 3.709.0
+      '@aws-sdk/credential-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
+      '@aws-sdk/types': 3.709.0
+      '@azure/identity': 4.5.0
+      '@azure/storage-blob': 12.26.0
+      '@backstage/backend-app-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/backend-dev-utils': 0.1.5
+      '@backstage/backend-plugin-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/cli-common': 0.1.15
+      '@backstage/cli-node': 0.2.13
+      '@backstage/config': 1.3.2
+      '@backstage/config-loader': 1.9.6(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      '@backstage/errors': 1.2.7
+      '@backstage/integration': 1.16.1
+      '@backstage/integration-aws-node': 0.1.15(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-events-node': 0.4.8(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
+      '@google-cloud/storage': 7.14.0
+      '@keyv/memcache': 2.0.1
+      '@keyv/redis': 4.2.0
       '@manypkg/get-packages': 1.1.3
       '@octokit/rest': 19.0.13
       '@opentelemetry/api': 1.9.0
@@ -9410,25 +9795,24 @@ snapshots:
       helmet: 6.2.0
       isomorphic-git: 1.27.2
       jose: 5.9.6
-      keyv: 4.5.4
+      keyv: 5.2.3
       knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
       lodash: 4.17.21
       logform: 2.7.0
       luxon: 3.5.0
       minimatch: 9.0.5
       minimist: 1.2.8
-      morgan: 1.10.0
       mysql2: 3.11.5
       node-fetch: 2.7.0
       node-forge: 1.3.1
       p-limit: 3.1.0
+      p-throttle: 4.1.1
       path-to-regexp: 8.2.0
       pg: 8.13.1
       pg-connection-string: 2.7.0
       pg-format: 1.0.4
       raw-body: 2.5.2
       selfsigned: 2.4.1
-      stoppable: 1.1.0
       tar: 6.2.1
       triple-beam: 1.4.1
       uuid: 11.0.3
@@ -9436,7 +9820,7 @@ snapshots:
       winston-transport: 4.9.0
       yauzl: 3.2.0
       yn: 4.0.0
-      zod: 3.24.1
+      zod: 3.24.2
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@swc/core'
@@ -9453,17 +9837,17 @@ snapshots:
 
   '@backstage/backend-dev-utils@0.1.5': {}
 
-  '@backstage/backend-plugin-api@1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
+  '@backstage/backend-plugin-api@1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
       '@backstage/cli-common': 0.1.15
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
-      '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/plugin-permission-common': 0.8.2
-      '@backstage/types': 1.2.0
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
       '@types/express': 4.17.21
       '@types/luxon': 3.4.2
-      express: 4.21.2
       knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
       luxon: 3.5.0
     transitivePeerDependencies:
@@ -9484,49 +9868,168 @@ snapshots:
       - tedious
       - utf-8-validate
 
+  '@backstage/backend-plugin-api@1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
+    dependencies:
+      '@backstage/cli-common': 0.1.15
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/luxon': 3.4.2
+      knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      luxon: 3.5.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/backend-plugin-api@1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)':
+    dependencies:
+      '@backstage/cli-common': 0.1.15
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/luxon': 3.4.2
+      knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      luxon: 3.5.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/backend-plugin-api@1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)':
+    dependencies:
+      '@backstage/cli-common': 0.1.15
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/luxon': 3.4.2
+      knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      luxon: 3.5.0
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@backstage/backend-plugin-api@1.2.0(mysql2@3.11.5)(pg@8.13.1)':
+    dependencies:
+      '@backstage/cli-common': 0.1.15
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/plugin-permission-node': 0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/luxon': 3.4.2
+      knex: 3.1.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      luxon: 3.5.0
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@backstage/catalog-client@1.8.0':
     dependencies:
-      '@backstage/catalog-model': 1.7.1
-      '@backstage/errors': 1.2.5
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/errors': 1.2.7
       cross-fetch: 4.0.0
       uri-template: 2.0.0
     transitivePeerDependencies:
       - encoding
 
-  '@backstage/catalog-model@1.7.1':
+  '@backstage/catalog-client@1.9.1':
     dependencies:
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/errors': 1.2.7
+      cross-fetch: 4.0.0
+      uri-template: 2.0.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@backstage/catalog-model@1.7.3':
+    dependencies:
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       ajv: 8.17.1
       lodash: 4.17.21
 
   '@backstage/cli-common@0.1.15': {}
 
-  '@backstage/cli-node@0.2.10':
+  '@backstage/cli-node@0.2.13':
     dependencies:
       '@backstage/cli-common': 0.1.15
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       '@manypkg/get-packages': 1.1.3
       '@yarnpkg/parsers': 3.0.2
       fs-extra: 11.2.0
       semver: 7.6.3
-      zod: 3.24.1
+      zod: 3.24.2
 
-  '@backstage/cli@0.29.2(@types/node@22.10.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))(type-fest@0.21.3)(typescript@5.7.2)':
+  '@backstage/cli@0.30.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(@types/node@22.10.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))(type-fest@0.21.3)(typescript@5.7.2)':
     dependencies:
-      '@backstage/catalog-model': 1.7.1
+      '@backstage/catalog-model': 1.7.3
       '@backstage/cli-common': 0.1.15
-      '@backstage/cli-node': 0.2.10
-      '@backstage/config': 1.3.0
-      '@backstage/config-loader': 1.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))
-      '@backstage/errors': 1.2.5
+      '@backstage/cli-node': 0.2.13
+      '@backstage/config': 1.3.2
+      '@backstage/config-loader': 1.9.6(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      '@backstage/errors': 1.2.7
       '@backstage/eslint-plugin': 0.1.10
-      '@backstage/integration': 1.15.2
-      '@backstage/release-manifests': 0.0.11
-      '@backstage/types': 1.2.0
+      '@backstage/integration': 1.16.1
+      '@backstage/release-manifests': 0.0.12
+      '@backstage/types': 1.2.1
       '@manypkg/get-packages': 1.1.3
-      '@module-federation/enhanced': 0.7.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      '@module-federation/enhanced': 0.8.12(@rspack/core@1.2.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       '@octokit/graphql': 5.0.6
       '@octokit/graphql-schema': 13.10.0
       '@octokit/oauth-app': 4.2.4
@@ -9537,8 +10040,8 @@ snapshots:
       '@rollup/plugin-node-resolve': 15.3.0(rollup@4.28.1)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.28.1)
       '@spotify/eslint-config-base': 15.0.0(eslint@8.57.1)
-      '@spotify/eslint-config-react': 15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
-      '@spotify/eslint-config-typescript': 15.0.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
+      '@spotify/eslint-config-react': 15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.1.0(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
+      '@spotify/eslint-config-typescript': 15.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
       '@sucrase/webpack-loader': 2.0.0(sucrase@3.35.0)
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
@@ -9550,8 +10053,8 @@ snapshots:
       '@swc/jest': 0.2.37(@swc/core@1.10.1(@swc/helpers@0.5.15))
       '@types/jest': 29.5.14
       '@types/webpack-env': 1.18.5
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       bfj: 8.0.0
@@ -9561,20 +10064,20 @@ snapshots:
       commander: 12.1.0
       cross-fetch: 4.0.0
       cross-spawn: 7.0.6
-      css-loader: 7.1.2(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      css-loader: 6.11.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       ctrlc-windows: 2.1.0
       esbuild: 0.24.0
       esbuild-loader: 4.2.2(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
       eslint-formatter-friendly: 7.0.0
-      eslint-plugin-deprecation: 2.0.0(eslint@8.57.1)(typescript@5.7.2)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
-      eslint-plugin-jest: 28.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2)
+      eslint-plugin-deprecation: 3.0.0(eslint@8.57.1)(typescript@5.7.2)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
+      eslint-plugin-jest: 28.9.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-unused-imports: 3.2.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)
       eslint-webpack-plugin: 4.2.0(eslint@8.57.1)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       express: 4.21.2
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
@@ -9584,7 +10087,7 @@ snapshots:
       global-agent: 3.0.0
       globby: 11.1.0
       handlebars: 4.7.8
-      html-webpack-plugin: 5.6.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
+      html-webpack-plugin: 5.6.3(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       inquirer: 8.2.6
       jest: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
       jest-cli: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
@@ -9595,11 +10098,9 @@ snapshots:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.9.2(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       minimatch: 9.0.5
-      node-fetch: 2.7.0
-      node-libs-browser: 2.2.1
+      node-stdlib-browser: 1.3.1
       npm-packlist: 5.1.3
       ora: 5.4.1
-      p-limit: 3.1.0
       p-queue: 6.6.2
       pirates: 4.0.6
       postcss: 8.4.49
@@ -9621,6 +10122,7 @@ snapshots:
       tar: 6.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
       ts-morph: 24.0.0
+      undici: 7.3.0
       util: 0.12.5
       webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
       webpack-dev-server: 5.1.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
@@ -9628,7 +10130,10 @@ snapshots:
       yargs: 16.2.0
       yml-loader: 2.1.0
       yn: 4.0.0
-      zod: 3.24.1
+      zod: 3.24.2
+      zod-validation-error: 3.4.0(zod@3.24.2)
+    optionalDependencies:
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - '@swc/wasm'
       - '@types/node'
@@ -9659,9 +10164,9 @@ snapshots:
   '@backstage/config-loader@1.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))':
     dependencies:
       '@backstage/cli-common': 0.1.15
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
       chokidar: 3.6.0
@@ -9679,15 +10184,36 @@ snapshots:
       - '@swc/wasm'
       - encoding
 
-  '@backstage/config@1.3.0':
+  '@backstage/config-loader@1.9.6(@swc/core@1.10.1(@swc/helpers@0.5.15))':
     dependencies:
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/cli-common': 0.1.15
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
+      '@types/json-schema': 7.0.15
+      ajv: 8.17.1
+      chokidar: 3.6.0
+      fs-extra: 11.2.0
+      json-schema: 0.4.0
+      json-schema-merge-allof: 0.8.1
+      json-schema-traverse: 1.0.0
+      lodash: 4.17.21
+      minimist: 1.2.8
+      typescript-json-schema: 0.65.1(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      yaml: 2.6.1
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+
+  '@backstage/config@1.3.2':
+    dependencies:
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       ms: 2.1.3
 
-  '@backstage/errors@1.2.5':
+  '@backstage/errors@1.2.7':
     dependencies:
-      '@backstage/types': 1.2.0
+      '@backstage/types': 1.2.1
       serialize-error: 8.1.0
 
   '@backstage/eslint-plugin@0.1.10':
@@ -9702,17 +10228,31 @@ snapshots:
       '@aws-sdk/credential-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
       '@aws-sdk/types': 3.709.0
       '@aws-sdk/util-arn-parser': 3.693.0
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@backstage/integration@1.15.2':
+  '@backstage/integration-aws-node@0.1.15(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))':
+    dependencies:
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/credential-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-arn-parser': 3.693.0
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+
+  '@backstage/integration@1.16.1':
     dependencies:
       '@azure/identity': 4.5.0
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
+      '@azure/storage-blob': 12.26.0
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
       '@octokit/auth-app': 4.0.13
       '@octokit/rest': 19.0.13
       cross-fetch: 4.0.0
@@ -9726,12 +10266,12 @@ snapshots:
   '@backstage/plugin-auth-node@0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
       '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(pg-connection-string@2.7.0)
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/backend-plugin-api': 1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
       '@backstage/catalog-client': 1.8.0
-      '@backstage/catalog-model': 1.7.1
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       '@types/express': 4.17.21
       '@types/passport': 1.0.17
       express: 4.21.2
@@ -9740,9 +10280,9 @@ snapshots:
       node-fetch: 2.7.0
       passport: 0.7.0
       winston: 3.17.0
-      zod: 3.24.1
-      zod-to-json-schema: 3.23.5(zod@3.24.1)
-      zod-validation-error: 3.4.0(zod@3.24.1)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
+      zod-validation-error: 3.4.0(zod@3.24.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@swc/core'
@@ -9761,11 +10301,84 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@backstage/plugin-events-node@0.4.5(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)':
+  '@backstage/plugin-auth-node@0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)
+      '@backstage/backend-plugin-api': 1.2.0(mysql2@3.11.5)(pg@8.13.1)
+      '@backstage/catalog-client': 1.8.0
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/passport': 1.0.17
+      express: 4.21.2
+      jose: 5.9.6
+      lodash: 4.17.21
+      node-fetch: 2.7.0
+      passport: 0.7.0
+      winston: 3.17.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
+      zod-validation-error: 3.4.0(zod@3.24.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/plugin-auth-node@0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/catalog-client': 1.9.1
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
+      '@types/express': 4.17.21
+      '@types/passport': 1.0.17
+      express: 4.21.2
+      jose: 5.9.6
+      lodash: 4.17.21
+      passport: 0.7.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
+      zod-validation-error: 3.4.0(zod@3.24.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/plugin-events-node@0.4.8(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       cross-fetch: 4.0.0
       uri-template: 2.0.0
     transitivePeerDependencies:
@@ -9779,31 +10392,31 @@ snapshots:
       - supports-color
       - tedious
 
-  '@backstage/plugin-permission-common@0.8.2':
+  '@backstage/plugin-permission-common@0.8.4':
     dependencies:
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
-      '@backstage/types': 1.2.0
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.1
       cross-fetch: 4.0.0
       uuid: 11.0.3
-      zod: 3.24.1
-      zod-to-json-schema: 3.23.5(zod@3.24.1)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
     transitivePeerDependencies:
       - encoding
 
-  '@backstage/plugin-permission-node@0.8.5(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
+  '@backstage/plugin-permission-node@0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
       '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(pg-connection-string@2.7.0)
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/config': 1.3.0
-      '@backstage/errors': 1.2.5
-      '@backstage/plugin-auth-node': 0.5.4(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/plugin-permission-common': 0.8.2
+      '@backstage/backend-plugin-api': 1.2.0(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg@8.13.1)
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
       '@types/express': 4.17.21
       express: 4.21.2
       express-promise-router: 4.1.1(@types/express@4.17.21)(express@4.21.2)
-      zod: 3.24.1
-      zod-to-json-schema: 3.23.5(zod@3.24.1)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@swc/core'
@@ -9822,23 +10435,85 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@backstage/plugin-scaffolder-common@1.5.7':
+  '@backstage/plugin-permission-node@0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
-      '@backstage/catalog-model': 1.7.1
-      '@backstage/plugin-permission-common': 0.8.2
-      '@backstage/types': 1.2.0
+      '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)
+      '@backstage/backend-plugin-api': 1.2.0(mysql2@3.11.5)(pg@8.13.1)
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@types/express': 4.17.21
+      express: 4.21.2
+      express-promise-router: 4.1.1(@types/express@4.17.21)(express@4.21.2)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/plugin-permission-node@0.8.8(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)':
+    dependencies:
+      '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)
+      '@backstage/backend-plugin-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/config': 1.3.2
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/plugin-permission-common': 0.8.4
+      '@types/express': 4.17.21
+      express: 4.21.2
+      express-promise-router: 4.1.1(@types/express@4.17.21)(express@4.21.2)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-connection-string
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - utf-8-validate
+
+  '@backstage/plugin-scaffolder-common@1.5.9':
+    dependencies:
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/plugin-permission-common': 0.8.4
+      '@backstage/types': 1.2.1
     transitivePeerDependencies:
       - encoding
 
-  '@backstage/plugin-scaffolder-node@0.6.1(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)':
+  '@backstage/plugin-scaffolder-node@0.7.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)':
     dependencies:
-      '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(pg-connection-string@2.7.0)
-      '@backstage/backend-plugin-api': 1.0.2(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(better-sqlite3@11.7.0)(mysql2@3.11.5)(pg-connection-string@2.7.0)(pg@8.13.1)
-      '@backstage/catalog-model': 1.7.1
-      '@backstage/errors': 1.2.5
-      '@backstage/integration': 1.15.2
-      '@backstage/plugin-scaffolder-common': 1.5.7
-      '@backstage/types': 1.2.0
+      '@backstage/backend-common': 0.25.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)
+      '@backstage/backend-plugin-api': 1.2.0(@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0))(@swc/core@1.10.1(@swc/helpers@0.5.15))(pg-connection-string@2.7.0)(pg@8.13.1)
+      '@backstage/catalog-model': 1.7.3
+      '@backstage/errors': 1.2.7
+      '@backstage/integration': 1.16.1
+      '@backstage/plugin-scaffolder-common': 1.5.9
+      '@backstage/types': 1.2.1
       concat-stream: 2.0.0
       fs-extra: 11.2.0
       globby: 11.1.0
@@ -9847,8 +10522,8 @@ snapshots:
       p-limit: 3.1.0
       tar: 6.2.1
       winston: 3.17.0
-      zod: 3.24.1
-      zod-to-json-schema: 3.23.5(zod@3.24.1)
+      zod: 3.24.2
+      zod-to-json-schema: 3.23.5(zod@3.24.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@swc/core'
@@ -9867,13 +10542,9 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@backstage/release-manifests@0.0.11':
-    dependencies:
-      cross-fetch: 4.0.0
-    transitivePeerDependencies:
-      - encoding
+  '@backstage/release-manifests@0.0.12': {}
 
-  '@backstage/types@1.2.0': {}
+  '@backstage/types@1.2.1': {}
 
   '@balena/dockerignore@1.0.2': {}
 
@@ -10110,6 +10781,10 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -10313,6 +10988,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
@@ -10334,11 +11017,27 @@ snapshots:
       json-buffer: 3.0.1
       memjs: 1.3.2
 
+  '@keyv/memcache@2.0.1':
+    dependencies:
+      '@keyv/serialize': 1.0.3
+      buffer: 6.0.3
+      memjs: 1.3.2
+
   '@keyv/redis@2.8.5':
     dependencies:
       ioredis: 5.4.1
     transitivePeerDependencies:
       - supports-color
+
+  '@keyv/redis@4.2.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      keyv: 5.2.3
+      redis: 4.7.0
+
+  '@keyv/serialize@1.0.3':
+    dependencies:
+      buffer: 6.0.3
 
   '@kubernetes/client-node@0.20.0':
     dependencies:
@@ -10362,6 +11061,24 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@kubernetes/client-node@0.22.3':
+    dependencies:
+      byline: 5.0.0
+      isomorphic-ws: 5.0.0(ws@8.18.0)
+      js-yaml: 4.1.0
+      jsonpath-plus: 10.3.0
+      request: 2.88.2
+      rfc4648: 1.5.4
+      stream-buffers: 3.0.3
+      tar: 7.4.3
+      tslib: 2.8.1
+      ws: 8.18.0
+    optionalDependencies:
+      openid-client: 6.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@manypkg/find-root@1.1.0':
@@ -10380,26 +11097,26 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@module-federation/bridge-react-webpack-plugin@0.7.7':
+  '@module-federation/bridge-react-webpack-plugin@0.8.12':
     dependencies:
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/sdk': 0.8.12
       '@types/semver': 7.5.8
       semver: 7.6.3
 
-  '@module-federation/data-prefetch@0.7.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@module-federation/data-prefetch@0.8.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@module-federation/runtime': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/runtime': 0.8.12
+      '@module-federation/sdk': 0.8.12
       fs-extra: 9.1.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@module-federation/dts-plugin@0.7.7(typescript@5.7.2)':
+  '@module-federation/dts-plugin@0.8.12(typescript@5.7.2)':
     dependencies:
-      '@module-federation/error-codes': 0.7.7
-      '@module-federation/managers': 0.7.7
-      '@module-federation/sdk': 0.7.7
-      '@module-federation/third-party-dts-extractor': 0.7.7
+      '@module-federation/error-codes': 0.8.12
+      '@module-federation/managers': 0.8.12
+      '@module-federation/sdk': 0.8.12
+      '@module-federation/third-party-dts-extractor': 0.8.12
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
       axios: 1.7.9
@@ -10419,22 +11136,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.7.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
+  '@module-federation/enhanced@0.8.12(@rspack/core@1.2.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.7.7
-      '@module-federation/data-prefetch': 0.7.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@module-federation/dts-plugin': 0.7.7(typescript@5.7.2)
-      '@module-federation/managers': 0.7.7
-      '@module-federation/manifest': 0.7.7(typescript@5.7.2)
-      '@module-federation/rspack': 0.7.7(typescript@5.7.2)
-      '@module-federation/runtime-tools': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/bridge-react-webpack-plugin': 0.8.12
+      '@module-federation/data-prefetch': 0.8.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@module-federation/dts-plugin': 0.8.12(typescript@5.7.2)
+      '@module-federation/error-codes': 0.8.12
+      '@module-federation/inject-external-runtime-core-plugin': 0.8.12(@module-federation/runtime-tools@0.8.12)
+      '@module-federation/managers': 0.8.12
+      '@module-federation/manifest': 0.8.12(typescript@5.7.2)
+      '@module-federation/rspack': 0.8.12(@rspack/core@1.2.6(@swc/helpers@0.5.15))(typescript@5.7.2)
+      '@module-federation/runtime-tools': 0.8.12
+      '@module-federation/sdk': 0.8.12
       btoa: 1.2.1
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.7.2
       webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
     transitivePeerDependencies:
+      - '@rspack/core'
       - bufferutil
       - debug
       - react
@@ -10442,19 +11162,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/error-codes@0.7.7': {}
+  '@module-federation/error-codes@0.8.12': {}
 
-  '@module-federation/managers@0.7.7':
+  '@module-federation/error-codes@0.8.4': {}
+
+  '@module-federation/inject-external-runtime-core-plugin@0.8.12(@module-federation/runtime-tools@0.8.12)':
     dependencies:
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/runtime-tools': 0.8.12
+
+  '@module-federation/managers@0.8.12':
+    dependencies:
+      '@module-federation/sdk': 0.8.12
       find-pkg: 2.0.0
       fs-extra: 9.1.0
 
-  '@module-federation/manifest@0.7.7(typescript@5.7.2)':
+  '@module-federation/manifest@0.8.12(typescript@5.7.2)':
     dependencies:
-      '@module-federation/dts-plugin': 0.7.7(typescript@5.7.2)
-      '@module-federation/managers': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/dts-plugin': 0.8.12(typescript@5.7.2)
+      '@module-federation/managers': 0.8.12
+      '@module-federation/sdk': 0.8.12
       chalk: 3.0.0
       find-pkg: 2.0.0
     transitivePeerDependencies:
@@ -10465,14 +11191,16 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rspack@0.7.7(typescript@5.7.2)':
+  '@module-federation/rspack@0.8.12(@rspack/core@1.2.6(@swc/helpers@0.5.15))(typescript@5.7.2)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.7.7
-      '@module-federation/dts-plugin': 0.7.7(typescript@5.7.2)
-      '@module-federation/managers': 0.7.7
-      '@module-federation/manifest': 0.7.7(typescript@5.7.2)
-      '@module-federation/runtime-tools': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/bridge-react-webpack-plugin': 0.8.12
+      '@module-federation/dts-plugin': 0.8.12(typescript@5.7.2)
+      '@module-federation/inject-external-runtime-core-plugin': 0.8.12(@module-federation/runtime-tools@0.8.12)
+      '@module-federation/managers': 0.8.12
+      '@module-federation/manifest': 0.8.12(typescript@5.7.2)
+      '@module-federation/runtime-tools': 0.8.12
+      '@module-federation/sdk': 0.8.12
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -10481,30 +11209,55 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/runtime-tools@0.7.7':
+  '@module-federation/runtime-core@0.6.20':
     dependencies:
-      '@module-federation/runtime': 0.7.7
-      '@module-federation/webpack-bundler-runtime': 0.7.7
+      '@module-federation/error-codes': 0.8.12
+      '@module-federation/sdk': 0.8.12
 
-  '@module-federation/runtime@0.7.7':
+  '@module-federation/runtime-tools@0.8.12':
     dependencies:
-      '@module-federation/error-codes': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/runtime': 0.8.12
+      '@module-federation/webpack-bundler-runtime': 0.8.12
 
-  '@module-federation/sdk@0.7.7':
+  '@module-federation/runtime-tools@0.8.4':
+    dependencies:
+      '@module-federation/runtime': 0.8.4
+      '@module-federation/webpack-bundler-runtime': 0.8.4
+
+  '@module-federation/runtime@0.8.12':
+    dependencies:
+      '@module-federation/error-codes': 0.8.12
+      '@module-federation/runtime-core': 0.6.20
+      '@module-federation/sdk': 0.8.12
+
+  '@module-federation/runtime@0.8.4':
+    dependencies:
+      '@module-federation/error-codes': 0.8.4
+      '@module-federation/sdk': 0.8.4
+
+  '@module-federation/sdk@0.8.12':
+    dependencies:
+      isomorphic-rslog: 0.0.7
+
+  '@module-federation/sdk@0.8.4':
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/third-party-dts-extractor@0.7.7':
+  '@module-federation/third-party-dts-extractor@0.8.12':
     dependencies:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/webpack-bundler-runtime@0.7.7':
+  '@module-federation/webpack-bundler-runtime@0.8.12':
     dependencies:
-      '@module-federation/runtime': 0.7.7
-      '@module-federation/sdk': 0.7.7
+      '@module-federation/runtime': 0.8.12
+      '@module-federation/sdk': 0.8.12
+
+  '@module-federation/webpack-bundler-runtime@0.8.4':
+    dependencies:
+      '@module-federation/runtime': 0.8.4
+      '@module-federation/sdk': 0.8.4
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -10701,6 +11454,32 @@ snapshots:
       type-fest: 0.21.3
       webpack-dev-server: 5.1.0(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0))
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/client@1.6.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/json@1.0.7(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/search@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
   '@rollup/plugin-commonjs@26.0.3(rollup@4.28.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.28.1)
@@ -10805,6 +11584,56 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.28.1':
     optional: true
+
+  '@rspack/binding-darwin-arm64@1.2.6':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.2.6':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.2.6':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.2.6':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.2.6':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.2.6':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.2.6':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.2.6':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.2.6':
+    optional: true
+
+  '@rspack/binding@1.2.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.2.6
+      '@rspack/binding-darwin-x64': 1.2.6
+      '@rspack/binding-linux-arm64-gnu': 1.2.6
+      '@rspack/binding-linux-arm64-musl': 1.2.6
+      '@rspack/binding-linux-x64-gnu': 1.2.6
+      '@rspack/binding-linux-x64-musl': 1.2.6
+      '@rspack/binding-win32-arm64-msvc': 1.2.6
+      '@rspack/binding-win32-ia32-msvc': 1.2.6
+      '@rspack/binding-win32-x64-msvc': 1.2.6
+
+  '@rspack/core@1.2.6(@swc/helpers@0.5.15)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.8.4
+      '@rspack/binding': 1.2.6
+      '@rspack/lite-tapable': 1.0.1
+      caniuse-lite: 1.0.30001701
+    optionalDependencies:
+      '@swc/helpers': 0.5.15
+
+  '@rspack/lite-tapable@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -11162,17 +11991,17 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@spotify/eslint-config-react@15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)':
+  '@spotify/eslint-config-react@15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.1.0(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
 
-  '@spotify/eslint-config-typescript@15.0.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)':
+  '@spotify/eslint-config-typescript@15.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
 
   '@sucrase/webpack-loader@2.0.0(sucrase@3.35.0)':
@@ -11594,73 +12423,75 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
+      '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/type-utils': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.25.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.6.3
-      ts-api-utils: 1.4.3(typescript@5.7.2)
-    optionalDependencies:
+      ts-api-utils: 2.0.1(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2)':
+  '@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.2)
-      '@typescript-eslint/visitor-keys': 6.21.0
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.25.0
       debug: 4.4.0
       eslint: 8.57.1
-    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@6.21.0':
+  '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/visitor-keys': 6.21.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/visitor-keys': 7.18.0
 
   '@typescript-eslint/scope-manager@8.18.0':
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.7.2)':
+  '@typescript-eslint/scope-manager@8.25.0':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.2)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/visitor-keys': 8.25.0
+
+  '@typescript-eslint/type-utils@8.25.0(eslint@8.57.1)(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
       debug: 4.4.0
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.7.2)
-    optionalDependencies:
+      ts-api-utils: 2.0.1(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@6.21.0': {}
+  '@typescript-eslint/types@7.18.0': {}
 
   '@typescript-eslint/types@8.18.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.7.2)':
+  '@typescript-eslint/types@8.25.0': {}
+
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/visitor-keys': 6.21.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
+      minimatch: 9.0.5
       semver: 7.6.3
       ts-api-utils: 1.4.3(typescript@5.7.2)
     optionalDependencies:
@@ -11682,16 +12513,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.7.2)':
+  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/visitor-keys': 8.25.0
+      debug: 4.4.0
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 2.0.1(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       eslint: 8.57.1
-      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11707,14 +12549,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@6.21.0':
+  '@typescript-eslint/utils@8.25.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/types': 6.21.0
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.2)
+      eslint: 8.57.1
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@7.18.0':
+    dependencies:
+      '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
   '@typescript-eslint/visitor-keys@8.18.0':
     dependencies:
       '@typescript-eslint/types': 8.18.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.25.0':
+    dependencies:
+      '@typescript-eslint/types': 8.25.0
       eslint-visitor-keys: 4.2.0
 
   '@ungap/structured-clone@1.2.1': {}
@@ -12019,10 +12877,13 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
-  assert@1.5.1:
+  assert@2.1.0:
     dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
       object.assign: 4.1.5
-      util: 0.10.4
+      util: 0.12.5
 
   ast-types-flow@0.0.8: {}
 
@@ -12240,6 +13101,10 @@ snapshots:
 
   brorand@1.1.0: {}
 
+  browser-resolve@2.0.0:
+    dependencies:
+      resolve: 1.22.8
+
   browserify-aes@1.2.0:
     dependencies:
       buffer-xor: 1.0.3
@@ -12310,12 +13175,6 @@ snapshots:
 
   buffer-xor@1.0.3: {}
 
-  buffer@4.9.2:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-      isarray: 1.0.0
-
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -12376,6 +13235,8 @@ snapshots:
 
   caniuse-lite@1.0.30001687: {}
 
+  caniuse-lite@1.0.30001701: {}
+
   caseless@0.12.0: {}
 
   chalk@2.4.2:
@@ -12415,6 +13276,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -12721,7 +13584,7 @@ snapshots:
     dependencies:
       postcss: 8.4.49
 
-  css-loader@7.1.2(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  css-loader@6.11.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -12732,6 +13595,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
       webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
 
   css-select@4.3.0:
@@ -12987,7 +13851,7 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
-  domain-browser@1.2.0: {}
+  domain-browser@4.22.0: {}
 
   domelementtype@2.3.0: {}
 
@@ -13288,27 +14152,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-deprecation@2.0.0(eslint@8.57.1)(typescript@5.7.2):
+  eslint-plugin-deprecation@3.0.0(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.7.2)
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -13319,7 +14183,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -13331,18 +14195,18 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2):
+  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/utils': 8.18.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
       jest: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.7.2))
     transitivePeerDependencies:
       - supports-color
@@ -13367,7 +14231,7 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
+  eslint-plugin-react-hooks@5.1.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
@@ -13393,14 +14257,11 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
-
-  eslint-rule-composer@0.3.0: {}
+      '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -13850,6 +14711,8 @@ snapshots:
     dependencies:
       loader-utils: 3.3.1
 
+  generic-pool@3.9.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -14121,7 +14984,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.37.0
 
-  html-webpack-plugin@5.6.3(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
+  html-webpack-plugin@5.6.3(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14129,6 +14992,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
       webpack: 5.97.1(@swc/core@1.10.1(@swc/helpers@0.5.15))(esbuild@0.24.0)
 
   htmlparser2@6.1.0:
@@ -14411,6 +15275,11 @@ snapshots:
 
   is-module@1.0.0: {}
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
   is-negative-zero@2.0.3: {}
 
   is-network-error@1.1.0: {}
@@ -14521,6 +15390,10 @@ snapshots:
       simple-get: 4.0.1
 
   isomorphic-rslog@0.0.6: {}
+
+  isomorphic-rslog@0.0.7: {}
+
+  isomorphic-timers-promises@1.0.1: {}
 
   isomorphic-ws@5.0.0(ws@8.18.0):
     dependencies:
@@ -14922,6 +15795,9 @@ snapshots:
 
   jose@5.9.6: {}
 
+  jose@6.0.8:
+    optional: true
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -14967,6 +15843,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  jsep@1.4.0: {}
 
   jsesc@3.0.2: {}
 
@@ -15017,6 +15895,12 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpath-plus@10.3.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsonpath-plus@7.2.0: {}
 
@@ -15084,6 +15968,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  keyv@5.2.3:
+    dependencies:
+      '@keyv/serialize': 1.0.3
 
   kind-of@6.0.3: {}
 
@@ -15391,10 +16279,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -15418,9 +16302,16 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.0.1:
+    dependencies:
+      minipass: 7.1.2
+      rimraf: 5.0.10
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   morgan@1.10.0:
     dependencies:
@@ -15501,32 +16392,6 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-libs-browser@2.2.1:
-    dependencies:
-      assert: 1.5.1
-      browserify-zlib: 0.2.0
-      buffer: 4.9.2
-      console-browserify: 1.2.0
-      constants-browserify: 1.0.0
-      crypto-browserify: 3.12.1
-      domain-browser: 1.2.0
-      events: 3.3.0
-      https-browserify: 1.0.0
-      os-browserify: 0.3.0
-      path-browserify: 0.0.1
-      process: 0.11.10
-      punycode: 1.4.1
-      querystring-es3: 0.2.1
-      readable-stream: 2.3.8
-      stream-browserify: 2.0.2
-      stream-http: 2.8.3
-      string_decoder: 1.3.0
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.0
-      url: 0.11.4
-      util: 0.11.1
-      vm-browserify: 1.1.2
-
   node-releases@2.0.19: {}
 
   node-schedule@2.1.1:
@@ -15534,6 +16399,36 @@ snapshots:
       cron-parser: 4.9.0
       long-timeout: 0.1.1
       sorted-array-functions: 1.3.0
+
+  node-stdlib-browser@1.3.1:
+    dependencies:
+      assert: 2.1.0
+      browser-resolve: 2.0.0
+      browserify-zlib: 0.2.0
+      buffer: 5.7.1
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      create-require: 1.1.1
+      crypto-browserify: 3.12.1
+      domain-browser: 4.22.0
+      events: 3.3.0
+      https-browserify: 1.0.0
+      isomorphic-timers-promises: 1.0.1
+      os-browserify: 0.3.0
+      path-browserify: 1.0.1
+      pkg-dir: 5.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 3.6.2
+      stream-browserify: 3.0.0
+      stream-http: 3.2.0
+      string_decoder: 1.3.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.1
+      url: 0.11.4
+      util: 0.12.5
+      vm-browserify: 1.1.2
 
   normalize-path@3.0.0: {}
 
@@ -15564,12 +16459,20 @@ snapshots:
 
   oauth-sign@0.9.0: {}
 
+  oauth4webapi@3.3.0:
+    optional: true
+
   object-assign@4.1.1: {}
 
   object-hash@2.2.0:
     optional: true
 
   object-inspect@1.13.3: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -15655,6 +16558,12 @@ snapshots:
       oidc-token-hash: 5.0.3
     optional: true
 
+  openid-client@6.3.3:
+    dependencies:
+      jose: 6.0.8
+      oauth4webapi: 3.3.0
+    optional: true
+
   optionator@0.8.3:
     dependencies:
       deep-is: 0.1.4
@@ -15722,6 +16631,8 @@ snapshots:
       is-network-error: 1.1.0
       retry: 0.13.1
 
+  p-throttle@4.1.1: {}
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
@@ -15785,8 +16696,6 @@ snapshots:
       passport-strategy: 1.0.0
       pause: 0.0.1
       utils-merge: 1.0.1
-
-  path-browserify@0.0.1: {}
 
   path-browserify@1.0.1: {}
 
@@ -15883,6 +16792,10 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-dir@5.0.0:
+    dependencies:
+      find-up: 5.0.0
 
   pkg-up@3.1.0:
     dependencies:
@@ -16340,6 +17253,15 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  redis@4.7.0:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
+      '@redis/client': 1.6.0
+      '@redis/graph': 1.1.1(@redis/client@1.6.0)
+      '@redis/json': 1.0.7(@redis/client@1.6.0)
+      '@redis/search': 1.2.0(@redis/client@1.6.0)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
+
   reflect.getprototypeof@1.0.8:
     dependencies:
       call-bind: 1.0.8
@@ -16484,6 +17406,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
 
   ripemd160@2.0.2:
     dependencies:
@@ -16853,10 +17779,10 @@ snapshots:
 
   stoppable@1.1.0: {}
 
-  stream-browserify@2.0.2:
+  stream-browserify@3.0.0:
     dependencies:
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 3.6.2
 
   stream-buffers@3.0.3: {}
 
@@ -16864,12 +17790,11 @@ snapshots:
     dependencies:
       stubs: 3.0.0
 
-  stream-http@2.8.3:
+  stream-http@3.2.0:
     dependencies:
       builtin-status-codes: 3.0.0
       inherits: 2.0.4
-      readable-stream: 2.3.8
-      to-arraybuffer: 1.0.1
+      readable-stream: 3.6.2
       xtend: 4.0.2
 
   stream-shift@1.0.3: {}
@@ -17085,6 +18010,15 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.1
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
   tarn@3.0.2: {}
 
   teeny-request@9.0.0:
@@ -17164,8 +18098,6 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  to-arraybuffer@1.0.1: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -17201,6 +18133,10 @@ snapshots:
   tryer@1.0.1: {}
 
   ts-api-utils@1.4.3(typescript@5.7.2):
+    dependencies:
+      typescript: 5.7.2
+
+  ts-api-utils@2.0.1(typescript@5.7.2):
     dependencies:
       typescript: 5.7.2
 
@@ -17259,18 +18195,11 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@1.14.1: {}
-
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
 
-  tsutils@3.21.0(typescript@5.7.2):
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.7.2
-
-  tty-browserify@0.0.0: {}
+  tty-browserify@0.0.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -17370,6 +18299,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici@7.3.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -17423,14 +18354,6 @@ snapshots:
       qs: 6.13.1
 
   util-deprecate@1.0.2: {}
-
-  util@0.10.4:
-    dependencies:
-      inherits: 2.0.3
-
-  util@0.11.1:
-    dependencies:
-      inherits: 2.0.3
 
   util@0.12.5:
     dependencies:
@@ -17730,6 +18653,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
+  yallist@5.0.0: {}
+
   yaml@1.10.2: {}
 
   yaml@2.6.1: {}
@@ -17782,12 +18707,12 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.5.2
 
-  zod-to-json-schema@3.23.5(zod@3.24.1):
+  zod-to-json-schema@3.23.5(zod@3.24.2):
     dependencies:
-      zod: 3.24.1
+      zod: 3.24.2
 
-  zod-validation-error@3.4.0(zod@3.24.1):
+  zod-validation-error@3.4.0(zod@3.24.2):
     dependencies:
-      zod: 3.24.1
+      zod: 3.24.2
 
-  zod@3.24.1: {}
+  zod@3.24.2: {}


### PR DESCRIPTION
Updated the versions of all packages but skipped the jump to `1.0.0` for `@kubernetes/client-node` due to risk of breakage.