### PR TITLE
Add OIDC authentication method

### DIFF
--- a/src/actions/apply.ts
+++ b/src/actions/apply.ts
@@ -10,6 +10,7 @@ type ApplyActionInput = {
   manifest: string;
   namespaced: boolean;
   clusterName?: string;
+  token?: string;
 };
 
 export const apply = (
@@ -29,6 +30,12 @@ export const apply = (
           .string()
           .optional()
           .describe("The name of the Kubernetes cluster to use (from app-config)"),
+        token: z
+          .string()
+          .optional()
+          .describe(
+            'An optional OIDC token that will be used to authenticate to the Kubernetes cluster',
+          ),
       }),
     },
 
@@ -38,7 +45,8 @@ export const apply = (
           ctx.input.manifest,
           ctx.logger,
           kubeClientFactory,
-          ctx.input.clusterName
+          ctx.input.clusterName,
+          ctx.input.token
         );
         if (ctx.namespaced) {
           ctx.logger.info(

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -12,6 +12,7 @@ type DeleteActionInput = {
   kind: string;
   name: string;
   clusterName?: string;
+  token?: string;
 };
 
 export const deleteAction = (
@@ -32,6 +33,12 @@ export const deleteAction = (
           .string()
           .optional()
           .describe("The name of the Kubernetes cluster to use (from app-config)"),
+        token: z
+          .string()
+          .optional()
+          .describe(
+            'An optional OIDC token that will be used to authenticate to the Kubernetes cluster',
+          ),
       }),
     },
 
@@ -44,7 +51,8 @@ export const deleteAction = (
           ctx.input.namespace,
           ctx.logger,
           kubeClientFactory,
-          ctx.input.clusterName
+          ctx.input.clusterName,
+          ctx.input.token
         );
         ctx.logger.info(`Successfully deleted the resource`);
       } catch (e) {

--- a/src/lib/apply.ts
+++ b/src/lib/apply.ts
@@ -7,7 +7,8 @@ export async function kubeApply(
   specString: string,
   logger: any,
   kubeClientFactory?: KubernetesClientFactory,
-  clusterName?: string
+  clusterName?: string,
+  token?: string
 ): Promise<k8s.KubernetesObjectWithSpec[]> {
   let client: k8s.KubernetesObjectApi;
 
@@ -15,6 +16,7 @@ export async function kubeApply(
     // Use the KubernetesClientFactory if provided
     client = kubeClientFactory.getObjectsClient({
       clusterName: clusterName,
+      token: token,
     });
     logger.info(`Using KubernetesClientFactory for cluster: ${clusterName || 'default'}`);
   } else {

--- a/src/lib/delete.ts
+++ b/src/lib/delete.ts
@@ -8,7 +8,8 @@ export async function kubeDelete(
   namespace: string,
   logger: any,
   kubeClientFactory?: KubernetesClientFactory,
-  clusterName?: string
+  clusterName?: string,
+  token?: string
 ) {
   let client: k8s.KubernetesObjectApi;
 
@@ -17,6 +18,7 @@ export async function kubeDelete(
     client = kubeClientFactory.getObjectsClient({
       clusterName: clusterName,
       namespace: namespace,
+      token: token,
     });
     logger.info(`Using KubernetesClientFactory for cluster: ${clusterName || 'default'}`);
   } else {


### PR DESCRIPTION
Thanks for the great plugin! We wanted to use it in our Backstage instance, but we use OIDC authentication to access Kubernetes clusters. Do you accept contributions?

This pull request adds support for OIDC authentication. The changes include updates to the action inputs, and the Kubernetes client factory to handle OIDC tokens.

Changes in the `kubernetes-client-factory.ts`:
- The `initializeClusters` method now supports clusters using OIDC authentication. During initialization, it creates a kubeconfig with a placeholder user, and when actions run, a new kubeconfig is generated using the token provided by the user.
- The `getKubeConfig` method has been updated so that if the cluster uses OIDC authentication, it generates a new kubeconfig using the token provided by the user.

The test file `kubernetes-client-factory.test.ts` wasn't updated in this PR. It contains a duplicated version of the `KubernetesClientFactory`. What approach is expected here? Should the implementation in the test file be updated to reflect the changes in the main implementation?